### PR TITLE
Change the way portable is activated

### DIFF
--- a/KRegExp/KRegExp.vcxproj
+++ b/KRegExp/KRegExp.vcxproj
@@ -42,6 +42,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>KRegExp</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -68,7 +69,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
   </PropertyGroup>

--- a/RegExp/LocationManager.cpp
+++ b/RegExp/LocationManager.cpp
@@ -96,7 +96,7 @@ bool LocationManager::Load(PCWSTR path) {
     ::GetModuleFileName(nullptr, fullpath, _countof(fullpath));
     auto ch = fullpath[3];
     fullpath[3] = 0;
-    if (::GetDriveType(fullpath) == DRIVE_FIXED)
+    if (std::filesystem::exists(ch))
         return LoadFromRegistry(path);
     fullpath[3] = ch;
     wcscpy_s(fullpath + wcslen(fullpath) - 3, _countof(fullpath), L"ini");


### PR DESCRIPTION
Theoretically, making a TotalReg.ini file will activate portable mode.

In practice? I have no idea because I cannot figure out how to compile this project for the life of me. The only WDK compatible with VS2022 is for Windows 11, and if there was a special preview build edition of WDK.vsix for Windows 10 VS2022, it's gone now.