### PR TITLE
New features and bugfixes

### DIFF
--- a/RegExp/MainFrame.h
+++ b/RegExp/MainFrame.h
@@ -294,6 +294,7 @@ private:
 	LRESULT OnDeleteBookmark(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 	LRESULT OnManageLocations(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 
+	void ConnectRemoteRegistry(CString hostname);
 	void InitCommandBar();
 	void InitToolBar(CToolBarCtrl& tb, int size = 24);
 	CTreeItem InsertTreeItem(PCWSTR text, int image, NodeType type, HTREEITEM hParent = TVI_ROOT, HTREEITEM hAfter = TVI_SORT);


### PR DESCRIPTION
- now it is possible to pass a registrypath to a remote computer on startup
- when browsing a remote registry the known locations map to the selected remote computer

Bugfixes:
- when passing a registrypath via commandline the last opened path is now ignored
- remote connections didn't work when the hostname was not written in upper case
- BuildKeyPath was asuming a fixed length for the hostname