### PR TITLE
Jump to hive implementation

### DIFF
--- a/RegExp/MainFrame.h
+++ b/RegExp/MainFrame.h
@@ -164,6 +164,9 @@ public:
 		COMMAND_ID_HANDLER(ID_KEY_ADDBOOKMARK, OnAddBookmark)
 		COMMAND_ID_HANDLER(ID_DELETE_BOOKMARK, OnDeleteBookmark)
 		COMMAND_ID_HANDLER(ID_LOCATIONS_MANAGE, OnManageLocations)
+		COMMAND_ID_HANDLER(ID_GOTOHIVE_CURRENTUSER, OnGotoHive)
+		COMMAND_ID_HANDLER(ID_GOTOHIVE_LOCALMACHINE, OnGotoHive)
+		COMMAND_ID_HANDLER(ID_GOTOHIVE_CLASSESROOT, OnGotoHive)
 		MESSAGE_HANDLER(WM_SHOWWINDOW, OnShowWindow)
 		MESSAGE_HANDLER(WM_CREATE, OnCreate)
 		MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
@@ -295,6 +298,7 @@ private:
 	LRESULT OnDeleteBookmark(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 	LRESULT OnManageLocations(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 	LRESULT OnViewSelectAll(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
+	LRESULT OnGotoHive(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 
 	void ConnectRemoteRegistry(CString hostname);
 	void InitCommandBar();

--- a/RegExp/resource.h
+++ b/RegExp/resource.h
@@ -196,6 +196,9 @@
 #define ID_KEY_ADDBOOKMARK              32882
 #define ID_DELETE_BOOKMARK              32883
 #define ID_VIEW_SELECTALL               32887
+#define ID_GOTOHIVE_CURRENTUSER         32888
+#define ID_GOTOHIVE_LOCALMACHINE        32889
+#define ID_GOTOHIVE_CLASSESROOT         32890
 
 // Next default values for new objects
 // 
@@ -203,7 +206,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        182
-#define _APS_NEXT_COMMAND_VALUE         32890
+#define _APS_NEXT_COMMAND_VALUE         32891
 #define _APS_NEXT_CONTROL_VALUE         1060
 #define _APS_NEXT_SYMED_VALUE           115
 #endif


### PR DESCRIPTION
Hi, I really enjoy using TotalRegistry.

With regedit.exe, one can jump from HKCU to HKLM (and back) if the key exists in the other hive.  
![image](https://github.com/user-attachments/assets/73b4df9a-9988-430c-85de-7511906d447c)

I implemented the same (and a bit more) in TotalRegistry.
![image](https://github.com/user-attachments/assets/89fff082-1877-4e6e-9084-5c500cf16905)

In this implementation, you can: 
- jump from **HKCU** to **HKLM** (and back) if the key exists in the other hive
- jump from **HKLM\Software\Classes\X** to **HKCR\X**
- jump from **HKCU\Software\Classes\X** to **HKCR\X**
- jump from **HKCR\X** to **HKLM\Software\Classes\X** (if the key exists HKLM)
- jump from **HKCR\X** to **HKCU\Software\Classes\X** (if the key exists HKCU)

Feel free to ask for changes in style, form or functionnality and I will gladly resubmit.